### PR TITLE
Fix "Consider dict comprehensions instead of using 'dict()'" issue

### DIFF
--- a/examples/urlExtractorNew.py
+++ b/examples/urlExtractorNew.py
@@ -28,7 +28,7 @@ for toks,strt,end in link.scanString(htmlText):
 # Create dictionary from list comprehension, assembled from each pair of tokens returned 
 # from a matched URL.
 pprint.pprint( 
-    dict( [ (toks.body,toks.startA.href) for toks,strt,end in link.scanString(htmlText) ] )
+    {toks.body: toks.startA.href for toks,strt,end in link.scanString(htmlText)}
     )
 
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Consider dict comprehensions instead of using 'dict()'](https://www.quantifiedcode.com/app/issue_class/539Wia7V)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:pyparsing?groups=code_patterns/%3A539Wia7V](https://www.quantifiedcode.com/app/project/gh:vmuriart:pyparsing?groups=code_patterns/%3A539Wia7V)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
