### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/examples/SimpleCalc.py
+++ b/examples/SimpleCalc.py
@@ -52,7 +52,7 @@ def evaluateStack( s ):
     elif op[0].isalpha():
         if op in variables:
             return variables[op]
-        raise Exception("invalid identifier '%s'" % op)
+        raise Exception("invalid identifier '{0!s}'".format(op))
     else:
         return float( op )
 

--- a/examples/TAP.py
+++ b/examples/TAP.py
@@ -104,7 +104,7 @@ class TAPSummary(object):
             testnum = i+1
             if res.testNumber != "":
                 if testnum != int(res.testNumber):
-                    print("ERROR! test %(testNumber)s out of sequence" % res)
+                    print("ERROR! test {testNumber!s} out of sequence".format(**res))
                 testnum = int(res.testNumber)
             res["testNumber"] = testnum
 
@@ -123,15 +123,15 @@ class TAPSummary(object):
         testListStr = lambda tl : "[" + ",".join(str(t.num) for t in tl) + "]"
         summaryText = []
         if showPassed or showAll:
-            summaryText.append( "PASSED: %s" % testListStr(self.passedTests) )
+            summaryText.append( "PASSED: {0!s}".format(testListStr(self.passedTests)) )
         if self.failedTests or showAll:
-            summaryText.append( "FAILED: %s" % testListStr(self.failedTests) )
+            summaryText.append( "FAILED: {0!s}".format(testListStr(self.failedTests)) )
         if self.skippedTests or showAll:
-            summaryText.append( "SKIPPED: %s" % testListStr(self.skippedTests) )
+            summaryText.append( "SKIPPED: {0!s}".format(testListStr(self.skippedTests)) )
         if self.todoTests or showAll:
-            summaryText.append( "TODO: %s" % testListStr(self.todoTests) )
+            summaryText.append( "TODO: {0!s}".format(testListStr(self.todoTests)) )
         if self.bonusTests or showAll:
-            summaryText.append( "BONUS: %s" % testListStr(self.bonusTests) )
+            summaryText.append( "BONUS: {0!s}".format(testListStr(self.bonusTests)) )
         if self.passedSuite:
             summaryText.append( "PASSED" )
         else:

--- a/examples/adventureEngine.py
+++ b/examples/adventureEngine.py
@@ -66,9 +66,9 @@ class Room(object):
                 is_form = "are"
             else:
                 is_form = "is"
-            print("There %s %s here." % (is_form, enumerateItems(visibleItems)))
+            print("There {0!s} {1!s} here.".format(is_form, enumerateItems(visibleItems)))
         else:
-            print("You see %s." % (enumerateItems(visibleItems)))
+            print("You see {0!s}.".format((enumerateItems(visibleItems))))
             
 
 class Exit(Room):
@@ -206,7 +206,7 @@ class TakeCommand(Command):
             else:
                 print(subj.cantTakeMessage)
         else:
-            print("There is no %s here." % subj)
+            print("There is no {0!s} here.".format(subj))
 
 
 class DropCommand(Command):
@@ -225,7 +225,7 @@ class DropCommand(Command):
             rm.addItem(subj)
             player.drop(subj)
         else:
-            print("You don't have %s." % (aOrAn(subj)))
+            print("You don't have {0!s}.".format((aOrAn(subj))))
 
 class InventoryCommand(Command):
     def __init__(self, quals):
@@ -236,7 +236,7 @@ class InventoryCommand(Command):
         return "INVENTORY or INV or I - lists what items you have"
         
     def _doCommand(self, player):
-        print("You have %s." % enumerateItems( player.inv ))
+        print("You have {0!s}.".format(enumerateItems( player.inv )))
 
 class LookCommand(Command):
     def __init__(self, quals):
@@ -296,7 +296,7 @@ class UseCommand(Command):
             else:
                 print("You can't use that here.")
         else:
-            print("There is no %s here to use." % self.subject)
+            print("There is no {0!s} here to use.".format(self.subject))
 
 class OpenCommand(Command):
     def __init__(self, quals):
@@ -319,7 +319,7 @@ class OpenCommand(Command):
             else:
                 print("You can't open that.")
         else:
-            print("There is no %s here to open." % self.subject)
+            print("There is no {0!s} here to open.".format(self.subject))
 
 class CloseCommand(Command):
     def __init__(self, quals):
@@ -342,7 +342,7 @@ class CloseCommand(Command):
             else:
                 print("You can't close that.")
         else:
-            print("There is no %s here to close." % self.subject)
+            print("There is no {0!s} here to close.".format(self.subject))
 
 class QuitCommand(Command):
     def __init__(self, quals):
@@ -379,7 +379,7 @@ class HelpCommand(Command):
             QuitCommand,
             HelpCommand,
             ]:
-            print("  - %s" % cmd.helpDescription())
+            print("  - {0!s}".format(cmd.helpDescription()))
         print()
 
 class AppParseException(ParseException):
@@ -453,7 +453,7 @@ class Parser(object):
     def validateItemName(self,s,l,t):
         iname = " ".join(t)
         if iname not in Item.items:
-            raise AppParseException(s,l,"No such item '%s'." % iname)
+            raise AppParseException(s,l,"No such item '{0!s}'.".format(iname))
         return iname
 
     def parseCmd(self, cmdstr):
@@ -487,7 +487,7 @@ class Player(object):
     
     def take(self,it):
         if it.isDeadly:
-            print("Aaaagh!...., the %s killed me!" % it)
+            print("Aaaagh!...., the {0!s} killed me!".format(it))
             self.gameOver = True
         else:
             self.inv.append(it)

--- a/examples/apicheck.py
+++ b/examples/apicheck.py
@@ -43,7 +43,7 @@ api_scanner = apiRef.scanString(test)
 while 1:
     try:
         t,s,e = next(api_scanner)
-        print("found %s on line %d" % (t.procname, lineno(s,test)))
+        print("found {0!s} on line {1:d}".format(t.procname, lineno(s,test)))
     except ParseSyntaxException as pe:
         print("invalid arg count on line", pe.lineno)
         print(pe.lineno,':',pe.line)

--- a/examples/btpyparse.py
+++ b/examples/btpyparse.py
@@ -18,7 +18,7 @@ class Macro(object):
     def __init__(self, name):
         self.name = name
     def __repr__(self):
-        return 'Macro("%s")' % self.name
+        return 'Macro("{0!s}")'.format(self.name)
     def __eq__(self, other):
         return self.name == other.name
     def __ne__(self, other):

--- a/examples/cLibHeader.py
+++ b/examples/cLibHeader.py
@@ -22,4 +22,4 @@ functionCall = Keyword("int") + ident("name") + "(" + arglist("args") + ")" + ";
 for fn,s,e in functionCall.scanString(testdata):
     print(fn.name)
     for a in fn.args:
-        print(" - %(name)s (%(type)s)" % a)
+        print(" - {name!s} ({type!s})".format(**a))

--- a/examples/cpp_enum_parser.py
+++ b/examples/cpp_enum_parser.py
@@ -48,5 +48,5 @@ for item,start,stop in enum.scanString(sample):
     for entry in item.names:
         if entry.value != '':
             id = int(entry.value)
-        print('%s_%s = %d' % (item.enum.upper(),entry.name.upper(),id))
+        print('{0!s}_{1!s} = {2:d}'.format(item.enum.upper(), entry.name.upper(), id))
         id += 1

--- a/examples/datetimeParseActions.py
+++ b/examples/datetimeParseActions.py
@@ -29,8 +29,7 @@ def convertToDatetime(s,loc,tokens):
         # on the integer expression above
         return datetime(tokens.year, tokens.month, tokens.day).date()
     except Exception as ve:
-        errmsg = "'%d/%d/%d' is not a valid date, %s" % \
-            (tokens.year, tokens.month, tokens.day, ve)
+        errmsg = "'{0:d}/{1:d}/{2:d}' is not a valid date, {3!s}".format(tokens.year, tokens.month, tokens.day, ve)
         raise ParseException(s, loc, errmsg)
 date_expr.setParseAction(convertToDatetime)
 

--- a/examples/deltaTime.py
+++ b/examples/deltaTime.py
@@ -206,7 +206,7 @@ if __name__ == "__main__":
      
     for t in tests:
         t = t.strip()
-        print(t, "(relative to %s)" % datetime.now())
+        print(t, "(relative to {0!s})".format(datetime.now()))
         res = nlTimeExpression.parseString(t)
         if "calculatedTime" in res:
             print(res.calculatedTime)

--- a/examples/dhcpd_leases_parser.py
+++ b/examples/dhcpd_leases_parser.py
@@ -59,7 +59,7 @@ dateRef = oneOf(list("0123456"))("weekday") + yyyymmdd("date") + \
                                                         hhmmss("time")
 
 def utcToLocalTime(tokens):
-    utctime = datetime.datetime.strptime("%(date)s %(time)s" % tokens,
+    utctime = datetime.datetime.strptime("{date!s} {time!s}".format(**tokens),
                                                     "%Y/%m/%d %H:%M:%S")
     localtime = utctime-datetime.timedelta(0,time.timezone,0)
     tokens["utcdate"],tokens["utctime"] = tokens["date"],tokens["time"]

--- a/examples/fourFn.py
+++ b/examples/fourFn.py
@@ -104,7 +104,7 @@ def evaluateStack( s ):
     elif op in fn:
         return fn[op]( evaluateStack( s ) )
     elif op[0].isalpha():
-        raise Exception("invalid identifier '%s'" % op)
+        raise Exception("invalid identifier '{0!s}'".format(op))
     else:
         return float( op )
 

--- a/examples/gen_ctypes.py
+++ b/examples/gen_ctypes.py
@@ -95,13 +95,13 @@ def getUDType(typestr):
     key = typestr.rstrip(" *")
     if key not in typemap:
         user_defined_types.add(key)
-        typemap[key] = "%s_%s" % (module, key)
+        typemap[key] = "{0!s}_{1!s}".format(module, key)
 
 def typeAsCtypes(typestr):
     if typestr in typemap:
         return typemap[typestr]
     if typestr.endswith("*"):
-        return "POINTER(%s)" % typeAsCtypes(typestr.rstrip(" *"))
+        return "POINTER({0!s})".format(typeAsCtypes(typestr.rstrip(" *")))
     return typestr
 
 # scan input header text for primitive typedefs
@@ -133,35 +133,35 @@ for en_,_,_ in enum_def.scanString(c_header):
         enum_constants.append( (ev.name, ev.value) )
 
 print("from ctypes import *")
-print("%s = CDLL('%s.dll')" % (module, module))
+print("{0!s} = CDLL('{1!s}.dll')".format(module, module))
 print()
 print("# user defined types")
 for tdname,tdtyp in typedefs:
-    print("%s = %s" % (tdname, typemap[tdtyp]))
+    print("{0!s} = {1!s}".format(tdname, typemap[tdtyp]))
 for fntd in fn_typedefs:
-    print("%s = CFUNCTYPE(%s)" % (fntd.fn_name,
+    print("{0!s} = CFUNCTYPE({1!s})".format(fntd.fn_name,
         ',\n    '.join(typeAsCtypes(a.argtype) for a in fntd.fn_args)))
 for udtype in user_defined_types:
-    print("class %s(Structure): pass" % typemap[udtype])
+    print("class {0!s}(Structure): pass".format(typemap[udtype]))
 
 print()
 print("# constant definitions")
 for en,ev in enum_constants:
-    print("%s = %s" % (en,ev))
+    print("{0!s} = {1!s}".format(en, ev))
 
 print()
 print("# functions")
 for fn in functions:
-    prefix = "%s.%s" % (module, fn.fn_name)
+    prefix = "{0!s}.{1!s}".format(module, fn.fn_name)
     
-    print("%s.restype = %s" % (prefix, typeAsCtypes(fn.fn_type)))
+    print("{0!s}.restype = {1!s}".format(prefix, typeAsCtypes(fn.fn_type)))
     if fn.varargs:
-        print("# warning - %s takes variable argument list" % prefix)
+        print("# warning - {0!s} takes variable argument list".format(prefix))
         del fn.fn_args[-1]
 
     if fn.fn_args.asList() != [['void']]:
-        print("%s.argtypes = (%s,)" % (prefix, ','.join(typeAsCtypes(a.argtype) for a in fn.fn_args)))
+        print("{0!s}.argtypes = ({1!s},)".format(prefix, ','.join(typeAsCtypes(a.argtype) for a in fn.fn_args)))
     else:
-        print("%s.argtypes = ()" % (prefix))
+        print("{0!s}.argtypes = ()".format((prefix)))
         
 

--- a/examples/getNTPserversNew.py
+++ b/examples/getNTPserversNew.py
@@ -31,5 +31,5 @@ serverListPage.close()
 
 addrs = {}
 for srvr,startloc,endloc in timeServerPattern.scanString( serverListHTML ):
-    print("%s (%s) - %s" % (srvr.ipAddr, srvr.hostname.strip(), srvr.loc.strip()))
+    print("{0!s} ({1!s}) - {2!s}".format(srvr.ipAddr, srvr.hostname.strip(), srvr.loc.strip()))
     addrs[srvr.ipAddr] = srvr.loc

--- a/examples/idlParse.py
+++ b/examples/idlParse.py
@@ -125,7 +125,7 @@ def test( strng ):
         tokens = bnf.parseString( strng )
         print("tokens = ")
         pprint.pprint( tokens.asList() )
-        imgname = "idlParse%02d.bmp" % testnum
+        imgname = "idlParse{0:02d}.bmp".format(testnum)
         testnum += 1
         #~ tree2image.str2image( str(tokens.asList()), imgname )
     except ParseException as err:

--- a/examples/linenoExample.py
+++ b/examples/linenoExample.py
@@ -18,9 +18,9 @@ of their country."""
 def reportLongWords(st,locn,toks):
     word = toks[0]
     if len(word) > 3:
-        print("Found '%s' on line %d at column %d" % (word, lineno(locn,st), col(locn,st)))
+        print("Found '{0!s}' on line {1:d} at column {2:d}".format(word, lineno(locn,st), col(locn,st)))
         print("The full line of text was:")
-        print("'%s'" % line(locn,st))
+        print("'{0!s}'".format(line(locn,st)))
         print((" "*col(locn,st))+" ^")
         print() 
         
@@ -38,7 +38,7 @@ class Token(object):
         self.lineNo = lineno(locn,st)
         self.col = col(locn,st)
     def __str__(self):
-        return "%(tokenString)s (line: %(lineNo)d, col: %(col)d)" % self.__dict__
+        return "{tokenString!s} (line: {lineNo:d}, col: {col:d})".format(**self.__dict__)
         
 def createTokenObject(st,locn,toks):
     return Token(st,locn, toks[0])

--- a/examples/partial_gene_match.py
+++ b/examples/partial_gene_match.py
@@ -72,7 +72,7 @@ class CloseMatch(Token):
 # using the genedata extracted above, look for close matches of a gene sequence
 searchseq = CloseMatch("TTAAATCTAGAAGAT", 3)
 for g in genedata: 
-    print("%s (%d)" % (g.id, g.genelen)) 
+    print("{0!s} ({1:d})".format(g.id, g.genelen)) 
     print("-"*24) 
     for t,startLoc,endLoc in searchseq.scanString(g.gene, overlap=True): 
         matched, mismatches = t[0] 

--- a/examples/protobuf_parser.py
+++ b/examples/protobuf_parser.py
@@ -17,7 +17,7 @@ LBRACE,RBRACE,LBRACK,RBRACK,LPAR,RPAR,EQ,SEMI = map(Suppress,"{}[]()=;")
 kwds = """message required optional repeated enum extensions extends extend 
           to package service rpc returns true false option import"""
 for kw in kwds.split():
-    exec("%s_ = Keyword('%s')" % (kw.upper(), kw))
+    exec("{0!s}_ = Keyword('{1!s}')".format(kw.upper(), kw))
 
 messageBody = Forward()
 

--- a/examples/pymicko.py
+++ b/examples/pymicko.py
@@ -291,10 +291,10 @@ class SemanticException(Exception):
         """String representation of the semantic error"""
         msg = "Error"
         if self.print_location and (self.line is not None):
-            msg += " at line %d, col %d" % (self.line, self.col)
-        msg += ": %s" % self.message
+            msg += " at line {0:d}, col {1:d}".format(self.line, self.col)
+        msg += ": {0!s}".format(self.message)
         if self.print_location and (self.line is not None):
-            msg += "\n%s" % self.text
+            msg += "\n{0!s}".format(self.text)
         return msg
 
 ##########################################################################################
@@ -347,7 +347,7 @@ class SymbolTable(object):
         if text == "":
             raise Exception("Symbol table index out of range")
         else:
-            raise Exception("Symbol table error: %s" % text)
+            raise Exception("Symbol table error: {0!s}".format(text))
 
     def display(self):
         """Displays the symbol table content"""
@@ -423,7 +423,7 @@ class SymbolTable(object):
             index = self.insert_symbol(sname, skind, stype)
             return index
         else:
-            raise SemanticException("Redefinition of '%s'" % sname)
+            raise SemanticException("Redefinition of '{0!s}'".format(sname))
 
     def insert_global_var(self, vname, vtype):
         "Inserts a new global variable"
@@ -458,10 +458,10 @@ class SymbolTable(object):
             num = int(cname)
             if ctype == SharedData.TYPES.INT:
                 if (num < SharedData.MIN_INT) or (num > SharedData.MAX_INT):
-                    raise SemanticException("Integer constant '%s' out of range" % cname)
+                    raise SemanticException("Integer constant '{0!s}' out of range".format(cname))
             elif ctype == SharedData.TYPES.UNSIGNED:
                 if (num < 0) or (num > SharedData.MAX_UNSIGNED):
-                    raise SemanticException("Unsigned constant '%s' out of range" % cname)
+                    raise SemanticException("Unsigned constant '{0!s}' out of range".format(cname))
             index = self.insert_symbol(cname, SharedData.KINDS.CONSTANT, ctype)
         return index
 
@@ -566,7 +566,7 @@ class CodeGenerator(object):
         """Compiler error exception. It should happen only if something is wrong with compiler.
            This exeption is not handled by the compiler, so as to allow traceback printing
         """
-        raise Exception("Compiler error: %s" % text)
+        raise Exception("Compiler error: {0!s}".format(text))
 
     def take_register(self, rtype = SharedData.TYPES.NO_TYPE):
         """Reserves one working register and sets its type"""
@@ -590,7 +590,7 @@ class CodeGenerator(object):
     def free_register(self, reg):
         """Releases working register"""
         if reg not in self.used_registers:
-            self.error("register %s is not taken" % self.REGISTERS[reg])
+            self.error("register {0!s} is not taken".format(self.REGISTERS[reg]))
         self.used_registers.remove(reg)
         self.free_registers.append(reg)
         self.free_registers.sort(reverse = True)
@@ -636,7 +636,7 @@ class CodeGenerator(object):
         self.used_registers_stack.append(used[:])
         used.sort()
         for reg in used:
-            self.newline_text("PUSH\t%s" % SharedData.REGISTERS[reg], True)
+            self.newline_text("PUSH\t{0!s}".format(SharedData.REGISTERS[reg]), True)
         self.free_registers.extend(used)
         self.free_registers.sort(reverse = True)
 
@@ -646,7 +646,7 @@ class CodeGenerator(object):
         self.used_registers = used[:]
         used.sort(reverse = True)
         for reg in used:
-            self.newline_text("POP \t%s" % SharedData.REGISTERS[reg], True)
+            self.newline_text("POP \t{0!s}".format(SharedData.REGISTERS[reg]), True)
             self.free_registers.remove(reg)
 
     def text(self, text):
@@ -752,11 +752,11 @@ class CodeGenerator(object):
 
     def push(self, operand):
         """Generates a push operation"""
-        self.newline_text("PUSH\t%s" % self.symbol(operand), True)
+        self.newline_text("PUSH\t{0!s}".format(self.symbol(operand)), True)
 
     def pop(self, operand):
         """Generates a pop instruction"""
-        self.newline_text("POP \t%s" % self.symbol(operand), True)
+        self.newline_text("POP \t{0!s}".format(self.symbol(operand)), True)
 
     def compare(self, operand1, operand2):
         """Generates a compare instruction
@@ -923,10 +923,10 @@ class MicroC(object):
             wline = lineno(exshared.location, exshared.text)
             wcol = col(exshared.location, exshared.text)
             wtext = line(exshared.location, exshared.text)
-            msg += " at line %d, col %d" % (wline, wcol)
-        msg += ": %s" % message
+            msg += " at line {0:d}, col {1:d}".format(wline, wcol)
+        msg += ": {0!s}".format(message)
         if print_location and (exshared.location is not None):
-            msg += "\n%s" % wtext
+            msg += "\n{0!s}".format(wtext)
         print(msg)
         
 
@@ -1040,7 +1040,7 @@ class MicroC(object):
             if DEBUG > 2: return
         var_index = self.symtab.lookup_symbol(var.name, [SharedData.KINDS.GLOBAL_VAR, SharedData.KINDS.PARAMETER, SharedData.KINDS.LOCAL_VAR])
         if var_index is None:
-            raise SemanticException("'%s' undefined" % var.name)
+            raise SemanticException("'{0!s}' undefined".format(var.name))
         return var_index
 
     def assignment_action(self, text, loc, assign):
@@ -1052,7 +1052,7 @@ class MicroC(object):
             if DEBUG > 2: return
         var_index = self.symtab.lookup_symbol(assign.var, [SharedData.KINDS.GLOBAL_VAR, SharedData.KINDS.PARAMETER, SharedData.KINDS.LOCAL_VAR])
         if var_index is None:
-            raise SemanticException("Undefined lvalue '%s' in assignment" % assign.var)
+            raise SemanticException("Undefined lvalue '{0!s}' in assignment".format(assign.var))
         if not self.symtab.same_types(var_index, assign.exp[0]):
             raise SemanticException("Incompatible types in assignment")
         self.codegen.move(assign.exp[0], var_index)
@@ -1068,7 +1068,7 @@ class MicroC(object):
         m = list(mul)
         while len(m) > 1:
             if not self.symtab.same_types(m[0], m[2]):
-                raise SemanticException("Invalid opernads to binary '%s'" % m[1])
+                raise SemanticException("Invalid opernads to binary '{0!s}'".format(m[1]))
             reg = self.codegen.arithmetic(m[1], m[0], m[2])
             #replace first calculation with it's result
             m[0:3] = [reg]
@@ -1085,7 +1085,7 @@ class MicroC(object):
         n = list(num)
         while len(n) > 1:
             if not self.symtab.same_types(n[0], n[2]):
-                raise SemanticException("Invalid opernads to binary '%s'" % n[1])
+                raise SemanticException("Invalid opernads to binary '{0!s}'".format(n[1]))
             reg = self.codegen.arithmetic(n[1], n[0], n[2])
             #replace first calculation with it's result
             n[0:3] = [reg]
@@ -1100,7 +1100,7 @@ class MicroC(object):
             if DEBUG > 2: return
         index = self.symtab.lookup_symbol(fun.name, SharedData.KINDS.FUNCTION)
         if index is None:
-            raise SemanticException("'%s' is not a function" % fun.name)
+            raise SemanticException("'{0!s}' is not a function".format(fun.name))
         #save any previous function call data (for nested function calls)
         self.function_call_stack.append(self.function_call_index)
         self.function_call_index = index
@@ -1118,7 +1118,7 @@ class MicroC(object):
         arg_ordinal = len(self.function_arguments)
         #check argument's type
         if not self.symtab.same_type_as_argument(arg.exp, self.function_call_index, arg_ordinal):
-            raise SemanticException("Incompatible type for argument %d in '%s'" % (arg_ordinal + 1, self.symtab.get_name(self.function_call_index)))
+            raise SemanticException("Incompatible type for argument {0:d} in '{1!s}'".format(arg_ordinal + 1, self.symtab.get_name(self.function_call_index)))
         self.function_arguments.append(arg.exp)
 
     def function_call_action(self, text, loc, fun):
@@ -1130,7 +1130,7 @@ class MicroC(object):
             if DEBUG > 2: return
         #check number of arguments
         if len(self.function_arguments) != self.symtab.get_attribute(self.function_call_index):
-            raise SemanticException("Wrong number of arguments for function '%s'" % fun.name)
+            raise SemanticException("Wrong number of arguments for function '{0!s}'".format(fun.name))
         #arguments should be pushed to stack in reverse order
         self.function_arguments.reverse()
         self.codegen.function_call(self.function_call_index, self.function_arguments)
@@ -1332,7 +1332,7 @@ if 0:
     try:
         parse = stdin if input_file == stdin else open(input_file,'r')
     except Exception:
-        print("Input file '%s' open error" % input_file)
+        print("Input file '{0!s}' open error".format(input_file))
         exit(2)
     mc.parse_file(parse)
     #if you want to see the final symbol table, uncomment next line
@@ -1342,7 +1342,7 @@ if 0:
         out.write(mc.codegen.code)
         out.close
     except Exception:
-        print("Output file '%s' open error" % output_file)
+        print("Output file '{0!s}' open error".format(output_file))
         exit(2)
 
 ##########################################################################################

--- a/examples/pythonGrammarParser.py
+++ b/examples/pythonGrammarParser.py
@@ -137,7 +137,7 @@ class SemanticGroup(object):
             self.contents = self.contents[:-1] + self.contents[-1].contents
         
     def __str__(self):
-        return "%s(%s)" % (self.label, 
+        return "{0!s}({1!s})".format(self.label, 
                 " ".join([isinstance(c,str) and c or str(c) for c in self.contents]) )
         
 class OrList(SemanticGroup):
@@ -164,7 +164,7 @@ class Atom(SemanticGroup):
             self.contents = contents[0]
             
     def __str__(self):
-        return "%s%s" % (self.rep, self.contents)
+        return "{0!s}{1!s}".format(self.rep, self.contents)
     
 def makeGroupObject(cls):
     def groupAction(s,l,t):
@@ -208,7 +208,7 @@ bnfDefs = bnf.parseString(grammar)
 # correct answer is 78
 expected = 78
 assert len(bnfDefs) == expected, \
-    "Error, found %d BNF defns, expected %d" % (len(bnfDefs), expected)
+    "Error, found {0:d} BNF defns, expected {1:d}".format(len(bnfDefs), expected)
 
 # list out defns in order they were parsed (to verify accuracy of parsing)
 for k,v in bnfDefs:

--- a/examples/rangeCheck.py
+++ b/examples/rangeCheck.py
@@ -24,9 +24,9 @@ def ranged_value(expr, minval=None, maxval=None):
         (False, False) : lambda s,l,t : minval <= t[0] <= maxval,
         }[minval is None, maxval is None]
     outOfRangeMessage = {
-        (True, False)  : "value is greater than %s" % maxval,
-        (False, True)  : "value is less than %s" % minval,
-        (False, False) : "value is not in the range (%s to %s)" % (minval,maxval),
+        (True, False)  : "value is greater than {0!s}".format(maxval),
+        (False, True)  : "value is less than {0!s}".format(minval),
+        (False, False) : "value is not in the range ({0!s} to {1!s})".format(minval, maxval),
         }[minval is None, maxval is None]
 
     return expr().addCondition(inRangeCondition, message=outOfRangeMessage)

--- a/examples/searchparser.py
+++ b/examples/searchparser.py
@@ -275,8 +275,8 @@ class ParserTest(SearchQueryParser):
             print(item)
             r = self.Parse(item)
             e = self.tests[item]
-            print('Result: %s' % r)
-            print('Expect: %s' % e)
+            print('Result: {0!s}'.format(r))
+            print('Expect: {0!s}'.format(e))
             if e == r:
                 print('Test OK')
             else:

--- a/examples/sexpParser.py
+++ b/examples/sexpParser.py
@@ -53,7 +53,7 @@ def verifyLen(s,l,t):
         t1len = len(t[1])
         if t1len != t.len:
             raise ParseFatalException(s,l,\
-                    "invalid data of length %d, expected %s" % (t1len, t.len))
+                    "invalid data of length {0:d}, expected {1!s}".format(t1len, t.len))
     return t[1]
 
 # define punctuation literals

--- a/examples/shapes.py
+++ b/examples/shapes.py
@@ -15,7 +15,7 @@ class Shape(object):
         raise NotImplementedException()
     
     def __str__(self):
-        return "<%s>: %s" % (self.__class__.__name__, self.__dict__)
+        return "<{0!s}>: {1!s}".format(self.__class__.__name__, self.__dict__)
 
 class Square(Shape):
     def area(self):

--- a/examples/simpleBool.py
+++ b/examples/simpleBool.py
@@ -31,7 +31,7 @@ class BoolBinOp(object):
     def __init__(self,t):
         self.args = t[0][0::2]
     def __str__(self):
-        sep = " %s " % self.reprsymbol
+        sep = " {0!s} ".format(self.reprsymbol)
         return "(" + sep.join(map(str,self.args)) + ")"
     def __bool__(self):
         return self.evalop(bool(a) for a in self.args)

--- a/examples/simpleWiki.py
+++ b/examples/simpleWiki.py
@@ -21,7 +21,7 @@ def convertToHTML_A(s,l,t):
         text,url=t[0].split("->")
     except ValueError:
         raise ParseFatalException(s,l,"invalid URL link reference: " + t[0])
-    return '<A href="%s">%s</A>' % (url,text)
+    return '<A href="{0!s}">{1!s}</A>'.format(url, text)
     
 urlRef = QuotedString("{{",endQuoteChar="}}").setParseAction(convertToHTML_A)
 

--- a/examples/sparser.py
+++ b/examples/sparser.py
@@ -79,12 +79,12 @@ def msg(txt):
 def debug(ftn, txt):
     """Used for debugging."""
     if debug_p:
-        sys.stdout.write("%s.%s:%s\n" % (modname, ftn, txt))
+        sys.stdout.write("{0!s}.{1!s}:{2!s}\n".format(modname, ftn, txt))
         sys.stdout.flush()
 
 def fatal(ftn, txt):
     """If can't continue."""
-    msg = "%s.%s:FATAL:%s\n" % (modname, ftn, txt)
+    msg = "{0!s}.{1!s}:FATAL:{2!s}\n".format(modname, ftn, txt)
     raise SystemExit(msg)
  
 def usage():

--- a/examples/sql2dot.py
+++ b/examples/sql2dot.py
@@ -70,7 +70,7 @@ create_table_def = Literal("CREATE") + "TABLE" + Word(alphas,alphanums+"_").setR
                     "("+field_list_def.setResultsName("columns")+")"+ ";"
 
 def create_table_act(toks):
-    return """"%(tablename)s" [\n\t label="<%(tablename)s> %(tablename)s | %(columns)s"\n\t shape="record"\n];""" % toks
+    return """"{tablename!s}" [\n\t label="<{tablename!s}> {tablename!s} | {columns!s}"\n\t shape="record"\n];""".format(**toks)
 create_table_def.setParseAction(create_table_act)
 
 add_fkey_def=Literal("ALTER")+"TABLE"+"ONLY" + Word(alphanums+"_").setResultsName("fromtable") + "ADD" \
@@ -78,7 +78,7 @@ add_fkey_def=Literal("ALTER")+"TABLE"+"ONLY" + Word(alphanums+"_").setResultsNam
     +"REFERENCES"+Word(alphanums+"_").setResultsName("totable")+"("+Word(alphanums+"_").setResultsName("tocolumn")+")"+";"    
 
 def add_fkey_act(toks):
-    return """ "%(fromtable)s":%(fromcolumn)s -> "%(totable)s":%(tocolumn)s """ % toks
+    return """ "{fromtable!s}":{fromcolumn!s} -> "{totable!s}":{tocolumn!s} """.format(**toks)
 add_fkey_def.setParseAction(add_fkey_act)
 
 other_statement_def = ( OneOrMore(CharsNotIn(";") )  + ";")

--- a/examples/stateMachine2.py
+++ b/examples/stateMachine2.py
@@ -58,7 +58,7 @@ def expand_state_definition(source, loc, tokens):
     # define base class for state classes
     baseStateClass = tokens.name + "State"
     statedef.extend([
-        "class %s(object):" % baseStateClass,
+        "class {0!s}(object):".format(baseStateClass),
         "    def __str__(self):",
         "        return self.__class__.__name__",
         "    def next_state(self):",
@@ -66,10 +66,10 @@ def expand_state_definition(source, loc, tokens):
     
     # define all state classes
     statedef.extend(
-        "class %s(%s): pass" % (s,baseStateClass) 
+        "class {0!s}({1!s}): pass".format(s, baseStateClass) 
             for s in states )
     statedef.extend(
-        "%s._next_state_class = %s" % (s,fromTo[s]) 
+        "{0!s}._next_state_class = {1!s}".format(s, fromTo[s]) 
             for s in states if s in fromTo )
            
     return indent + ("\n"+indent).join(statedef)+"\n"
@@ -102,14 +102,14 @@ def expand_named_state_definition(source,loc,tokens):
     
     # define state transition class
     statedef.extend([
-        "class %sTransition:" % baseStateClass,
+        "class {0!s}Transition:".format(baseStateClass),
         "    def __str__(self):",
         "        return self.transitionName",
         ])
     statedef.extend(
-        "%s = %sTransition()" % (tn,baseStateClass) 
+        "{0!s} = {1!s}Transition()".format(tn, baseStateClass) 
             for tn in transitions)
-    statedef.extend("%s.transitionName = '%s'" % (tn,tn) 
+    statedef.extend("{0!s}.transitionName = '{1!s}'".format(tn, tn) 
             for tn in transitions)
 
     # define base class for state classes
@@ -117,31 +117,28 @@ def expand_named_state_definition(source,loc,tokens):
         '.%s does not support transition "%s"' \
         "'% (self, tn)"
     statedef.extend([
-        "class %s(object):" % baseStateClass,
+        "class {0!s}(object):".format(baseStateClass),
         "    def __str__(self):",
         "        return self.__class__.__name__",
         "    def next_state(self,tn):",
         "        try:",
         "            return self.tnmap[tn]()",
         "        except KeyError:",
-        "            raise Exception(%s)" % excmsg,
+        "            raise Exception({0!s})".format(excmsg),
         "    def __getattr__(self,name):",
-        "        raise Exception(%s)" % excmsg,
+        "        raise Exception({0!s})".format(excmsg),
         ])
     
     # define all state classes
     for s in states:
-        statedef.append("class %s(%s): pass" % 
-                                    (s,baseStateClass))
+        statedef.append("class {0!s}({1!s}): pass".format(s, baseStateClass))
 
     # define state transition maps and transition methods
     for s in states:
         trns = list(fromTo[s].items())
-        statedef.append("%s.tnmap = {%s}" % 
-            (s, ",".join("%s:%s" % tn for tn in trns)) )
+        statedef.append("{0!s}.tnmap = {{{1!s}}}".format(s, ",".join("{0!s}:{1!s}".format(*tn) for tn in trns)) )
         statedef.extend([
-            "%s.%s = staticmethod(lambda : %s())" % 
-                                            (s,tn_,to_)
+            "{0!s}.{1!s} = staticmethod(lambda : {2!s}())".format(s, tn_, to_)
                 for tn_,to_ in trns
             ])
 
@@ -173,8 +170,8 @@ class SuffixImporter(object):
     @classmethod
     def trigger_url(cls):
         if cls.suffix is None:
-            raise ValueError('%s.suffix is not set' % cls.__name__)
-        return 'suffix:%s' % cls.suffix
+            raise ValueError('{0!s}.suffix is not set'.format(cls.__name__))
+        return 'suffix:{0!s}'.format(cls.suffix)
 
     @classmethod
     def register(cls):
@@ -197,7 +194,7 @@ class SuffixImporter(object):
             # it probably isn't even a filesystem path
             if sys.path_importer_cache.get(dirpath,False) is None:
                 checkpath = os.path.join(
-                        dirpath,'%s.%s' % (fullname,self.suffix))
+                        dirpath,'{0!s}.{1!s}'.format(fullname, self.suffix))
                 yield checkpath
     
     def find_module(self, fullname, path=None):

--- a/examples/wordsToNum.py
+++ b/examples/wordsToNum.py
@@ -78,7 +78,7 @@ numWords.ignore(Literal("-"))
 numWords.ignore(CaselessLiteral("and"))
 
 def test(s,expected):
-    print ("Expecting %s" % expected)
+    print ("Expecting {0!s}".format(expected))
     numWords.runTests(s)
 
 test("one hundred twenty hundred", None)

--- a/src/pyparsing/atomic.py
+++ b/src/pyparsing/atomic.py
@@ -54,7 +54,7 @@ class Literal(Token):
             warnings.warn("null string passed to Literal; use Empty() instead",
                           SyntaxWarning, stacklevel=2)
             self.__class__ = Empty
-        self.name = '"%s"' % _ustr(self.match)
+        self.name = '"{0!s}"'.format(_ustr(self.match))
         self.errmsg = "Expected " + self.name
         self.mayReturnEmpty = False
         self.mayIndexError = False
@@ -95,7 +95,7 @@ class Keyword(Token):
         except IndexError:
             warnings.warn("null string passed to Keyword; use Empty() instead",
                           SyntaxWarning, stacklevel=2)
-        self.name = '"%s"' % self.match
+        self.name = '"{0!s}"'.format(self.match)
         self.errmsg = "Expected " + self.name
         self.mayReturnEmpty = False
         self.mayIndexError = False
@@ -146,7 +146,7 @@ class CaselessLiteral(Literal):
         super(CaselessLiteral, self).__init__(matchString.upper())
         # Preserve the defining literal.
         self.returnString = matchString
-        self.name = "'%s'" % self.returnString
+        self.name = "'{0!s}'".format(self.returnString)
         self.errmsg = "Expected " + self.name
 
     def parseImpl(self, instring, loc, doActions=True):
@@ -225,16 +225,14 @@ class Word(Token):
         if ' ' not in self.initCharsOrig + self.bodyCharsOrig and (
                             min == 1 and max == 0 and exact == 0):
             if self.bodyCharsOrig == self.initCharsOrig:
-                self.reString = "[%s]+" % _escapeRegexRangeChars(
-                    self.initCharsOrig)
+                self.reString = "[{0!s}]+".format(_escapeRegexRangeChars(
+                    self.initCharsOrig))
             elif len(self.initCharsOrig) == 1:
-                self.reString = "%s[%s]*" % \
-                                (re.escape(self.initCharsOrig),
-                                 _escapeRegexRangeChars(self.bodyCharsOrig),)
+                self.reString = "{0!s}[{1!s}]*".format(re.escape(self.initCharsOrig),
+                                 _escapeRegexRangeChars(self.bodyCharsOrig))
             else:
-                self.reString = "[%s][%s]*" % \
-                                (_escapeRegexRangeChars(self.initCharsOrig),
-                                 _escapeRegexRangeChars(self.bodyCharsOrig),)
+                self.reString = "[{0!s}][{1!s}]*".format(_escapeRegexRangeChars(self.initCharsOrig),
+                                 _escapeRegexRangeChars(self.bodyCharsOrig))
             if self.asKeyword:
                 self.reString = r"\b" + self.reString + r"\b"
             try:
@@ -293,11 +291,11 @@ class Word(Token):
                     return s
 
             if self.initCharsOrig != self.bodyCharsOrig:
-                self.strRepr = "W:(%s,%s)" % (
+                self.strRepr = "W:({0!s},{1!s})".format(
                     charsAsStr(self.initCharsOrig),
                     charsAsStr(self.bodyCharsOrig))
             else:
-                self.strRepr = "W:(%s)" % charsAsStr(self.initCharsOrig)
+                self.strRepr = "W:({0!s})".format(charsAsStr(self.initCharsOrig))
 
         return self.strRepr
 
@@ -329,7 +327,7 @@ class Regex(Token):
                 self.re = re.compile(self.pattern, self.flags)
                 self.reString = self.pattern
             except sre_constants.error:
-                warnings.warn("invalid pattern (%s) passed to Regex" % pattern,
+                warnings.warn("invalid pattern ({0!s}) passed to Regex".format(pattern),
                               SyntaxWarning, stacklevel=2)
                 raise
 
@@ -368,7 +366,7 @@ class Regex(Token):
             pass
 
         if self.strRepr is None:
-            self.strRepr = "Re:(%s)" % repr(self.pattern)
+            self.strRepr = "Re:({0!s})".format(repr(self.pattern))
 
         return self.strRepr
 
@@ -426,38 +424,36 @@ class QuotedString(Token):
 
         if multiline:
             self.flags = re.MULTILINE | re.DOTALL
-            self.pattern = r'%s(?:[^%s%s]' % \
-                           (re.escape(self.quoteChar),
+            self.pattern = r'{0!s}(?:[^{1!s}{2!s}]'.format(re.escape(self.quoteChar),
                             _escapeRegexRangeChars(self.endQuoteChar[0]),
                             (escChar is not None and _escapeRegexRangeChars(
                                 escChar) or ''))
         else:
             self.flags = 0
-            self.pattern = r'%s(?:[^%s\n\r%s]' % \
-                           (re.escape(self.quoteChar),
+            self.pattern = r'{0!s}(?:[^{1!s}\n\r{2!s}]'.format(re.escape(self.quoteChar),
                             _escapeRegexRangeChars(self.endQuoteChar[0]),
                             (escChar is not None and _escapeRegexRangeChars(
                                 escChar) or ''))
         if len(self.endQuoteChar) > 1:
             self.pattern += (
                 '|(?:' + ')|(?:'.join(
-                    "%s[^%s]" % (re.escape(self.endQuoteChar[:i]),
+                    "{0!s}[^{1!s}]".format(re.escape(self.endQuoteChar[:i]),
                                  _escapeRegexRangeChars(self.endQuoteChar[i]))
                     for i in range(len(self.endQuoteChar) - 1, 0, -1)) + ')'
             )
         if escQuote:
-            self.pattern += (r'|(?:%s)' % re.escape(escQuote))
+            self.pattern += (r'|(?:{0!s})'.format(re.escape(escQuote)))
         if escChar:
-            self.pattern += (r'|(?:%s.)' % re.escape(escChar))
+            self.pattern += (r'|(?:{0!s}.)'.format(re.escape(escChar)))
             self.escCharReplacePattern = re.escape(self.escChar) + "(.)"
-        self.pattern += (r')*%s' % re.escape(self.endQuoteChar))
+        self.pattern += (r')*{0!s}'.format(re.escape(self.endQuoteChar)))
 
         try:
             self.re = re.compile(self.pattern, self.flags)
             self.reString = self.pattern
         except sre_constants.error:
             warnings.warn(
-                "invalid pattern (%s) passed to Regex" % self.pattern,
+                "invalid pattern ({0!s}) passed to Regex".format(self.pattern),
                 SyntaxWarning, stacklevel=2)
             raise
 
@@ -509,7 +505,7 @@ class QuotedString(Token):
             pass
 
         if self.strRepr is None:
-            self.strRepr = "quoted string, starting with %s ending with %s" % (
+            self.strRepr = "quoted string, starting with {0!s} ending with {1!s}".format(
                 self.quoteChar, self.endQuoteChar)
 
         return self.strRepr
@@ -574,9 +570,9 @@ class CharsNotIn(Token):
 
         if self.strRepr is None:
             if len(self.notChars) > 4:
-                self.strRepr = "!W:(%s...)" % self.notChars[:4]
+                self.strRepr = "!W:({0!s}...)".format(self.notChars[:4])
             else:
-                self.strRepr = "!W:(%s)" % self.notChars
+                self.strRepr = "!W:({0!s})".format(self.notChars)
 
         return self.strRepr
 

--- a/src/pyparsing/exceptions.py
+++ b/src/pyparsing/exceptions.py
@@ -34,8 +34,7 @@ class ParseBaseException(Exception):
             raise AttributeError(aname)
 
     def __str__(self):
-        return "%s (at char %d), (line:%d, col:%d)" % \
-               (self.msg, self.loc, self.lineno, self.column)
+        return "{0!s} (at char {1:d}), (line:{2:d}, col:{3:d})".format(self.msg, self.loc, self.lineno, self.column)
 
     def __repr__(self):
         return _ustr(self)
@@ -105,4 +104,4 @@ class RecursiveGrammarException(Exception):
         self.parseElementTrace = parseElementList
 
     def __str__(self):
-        return "RecursiveGrammarException: %s" % self.parseElementTrace
+        return "RecursiveGrammarException: {0!s}".format(self.parseElementTrace)

--- a/src/pyparsing/pyparsing.py
+++ b/src/pyparsing/pyparsing.py
@@ -310,7 +310,7 @@ class ParseResults(object):
             if k == 'default':
                 args = (args[0], v)
             else:
-                raise TypeError("pop() got an unexpected keyword argument '%s'" % k)
+                raise TypeError("pop() got an unexpected keyword argument '{0!s}'".format(k))
         if (isinstance(args[0], int) or
                         len(args) == 1 or
                         args[0] in self):
@@ -403,7 +403,7 @@ class ParseResults(object):
             return other + self
 
     def __repr__( self ):
-        return "(%s, %s)" % ( repr( self.__toklist ), repr( self.__tokdict ) )
+        return "({0!s}, {1!s})".format(repr( self.__toklist ), repr( self.__tokdict ) )
 
     def __str__( self ):
         return '[' + ', '.join(_ustr(i) if isinstance(i, ParseResults) else repr(i) for i in self.__toklist) + ']'
@@ -545,7 +545,7 @@ class ParseResults(object):
             for k,v in items:
                 if out:
                     out.append(NL)
-                out.append( "%s%s- %s: " % (indent,('  '*depth), k) )
+                out.append( "{0!s}{1!s}- {2!s}: ".format(indent, ('  '*depth), k) )
                 if isinstance(v,ParseResults):
                     if v:
                         out.append( v.dump(indent,depth+1) )
@@ -557,9 +557,9 @@ class ParseResults(object):
             v = self
             for i,vv in enumerate(v):
                 if isinstance(vv,ParseResults):
-                    out.append("\n%s%s[%d]:\n%s%s%s" % (indent,('  '*(depth)),i,indent,('  '*(depth+1)),vv.dump(indent,depth+1) ))
+                    out.append("\n{0!s}{1!s}[{2:d}]:\n{3!s}{4!s}{5!s}".format(indent, ('  '*(depth)), i, indent, ('  '*(depth+1)), vv.dump(indent,depth+1) ))
                 else:
-                    out.append("\n%s%s[%d]:\n%s%s%s" % (indent,('  '*(depth)),i,indent,('  '*(depth+1)),_ustr(vv)))
+                    out.append("\n{0!s}{1!s}[{2:d}]:\n{3!s}{4!s}{5!s}".format(indent, ('  '*(depth)), i, indent, ('  '*(depth+1)), _ustr(vv)))
 
         return "".join(out)
 
@@ -634,7 +634,7 @@ def line( loc, strg ):
         return strg[lastCR+1:]
 
 def _defaultStartDebugAction( instring, loc, expr ):
-    print (("Match " + _ustr(expr) + " at loc " + _ustr(loc) + "(%d,%d)" % ( lineno(loc,instring), col(loc,instring) )))
+    print (("Match " + _ustr(expr) + " at loc " + _ustr(loc) + "({0:d},{1:d})".format(lineno(loc,instring), col(loc,instring) )))
 
 def _defaultSuccessDebugAction( instring, startloc, endloc, expr, toks ):
     print ("Matched " + _ustr(expr) + " -> " + str(toks.asList()))
@@ -1220,7 +1220,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return And( [ self, other ] )
@@ -1230,7 +1230,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return other + self
@@ -1240,7 +1240,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return And( [ self, And._ErrorStop(), other ] )
@@ -1250,7 +1250,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return other - self
@@ -1331,7 +1331,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return MatchFirst( [ self, other ] )
@@ -1341,7 +1341,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return other | self
@@ -1351,7 +1351,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return Or( [ self, other ] )
@@ -1361,7 +1361,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return other ^ self
@@ -1371,7 +1371,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return Each( [ self, other ] )
@@ -1381,7 +1381,7 @@ class ParserElement(object):
         if isinstance( other, basestring ):
             other = ParserElement._literalStringClass( other )
         if not isinstance( other, ParserElement ):
-            warnings.warn("Cannot combine element of type %s with ParserElement" % type(other),
+            warnings.warn("Cannot combine element of type {0!s} with ParserElement".format(type(other)),
                     SyntaxWarning, stacklevel=2)
             return None
         return other & self
@@ -1791,7 +1791,7 @@ class ParseExpression(ParserElement):
             pass
 
         if self.strRepr is None:
-            self.strRepr = "%s:(%s)" % ( self.__class__.__name__, _ustr(self.exprs) )
+            self.strRepr = "{0!s}:({1!s})".format(self.__class__.__name__, _ustr(self.exprs) )
         return self.strRepr
 
     def streamline( self ):
@@ -2085,7 +2085,7 @@ class Each(ParseExpression):
 
         if tmpReqd:
             missing = ", ".join(_ustr(e) for e in tmpReqd)
-            raise ParseException(instring, loc, "Missing one or more required elements (%s)" % missing)
+            raise ParseException(instring, loc, "Missing one or more required elements ({0!s})".format(missing))
 
         # add any unmatched Optionals, in case they have default values defined
         matchOrder += [e for e in self.exprs if isinstance(e,Optional) and e.expr in tmpOpt]
@@ -2193,7 +2193,7 @@ class ParseElementEnhance(ParserElement):
             pass
 
         if self.strRepr is None and self.expr is not None:
-            self.strRepr = "%s:(%s)" % ( self.__class__.__name__, _ustr(self.expr) )
+            self.strRepr = "{0!s}:({1!s})".format(self.__class__.__name__, _ustr(self.expr) )
         return self.strRepr
 
 
@@ -2638,13 +2638,13 @@ def traceParseAction(f):
         s,l,t = paArgs[-3:]
         if len(paArgs)>3:
             thisFunc = paArgs[0].__class__.__name__ + '.' + thisFunc
-        sys.stderr.write( ">>entering %s(line: '%s', %d, %s)\n" % (thisFunc,line(l,s),l,t) )
+        sys.stderr.write( ">>entering {0!s}(line: '{1!s}', {2:d}, {3!s})\n".format(thisFunc, line(l,s), l, t) )
         try:
             ret = f(*paArgs)
         except Exception as exc:
-            sys.stderr.write( "<<leaving %s (exception: %s)\n" % (thisFunc,exc) )
+            sys.stderr.write( "<<leaving {0!s} (exception: {1!s})\n".format(thisFunc, exc) )
             raise
-        sys.stderr.write( "<<leaving %s (ret: %s)\n" % (thisFunc,ret) )
+        sys.stderr.write( "<<leaving {0!s} (ret: {1!s})\n".format(thisFunc, ret) )
         return ret
     try:
         z.__name__ = f.__name__
@@ -2813,7 +2813,7 @@ def oneOf( strs, caseless=False, useRegex=True ):
         #~ print (strs,"->", "|".join( [ _escapeRegexChars(sym) for sym in symbols] ))
         try:
             if len(symbols)==len("".join(symbols)):
-                return Regex("[%s]" % "".join(_escapeRegexRangeChars(sym) for sym in symbols)).setName(' | '.join(symbols))
+                return Regex("[{0!s}]".format("".join(_escapeRegexRangeChars(sym) for sym in symbols))).setName(' | '.join(symbols))
             else:
                 return Regex("|".join(re.escape(sym) for sym in symbols)).setName(' | '.join(symbols))
         except:
@@ -2921,7 +2921,7 @@ def matchOnlyAtCol(n):
     """
     def verifyCol(strg,locn,toks):
         if col(locn,strg) != n:
-            raise ParseException(strg, locn, "matched token not at column %d" % n)
+            raise ParseException(strg, locn, "matched token not at column {0:d}".format(n))
     return verifyCol
 
 def replaceWith(replStr):
@@ -2984,8 +2984,8 @@ def _makeTags(tagStr, xml):
                 Optional("/",default=[False]).setResultsName("empty").setParseAction(lambda s,l,t:t[0]=='/') + Suppress(">")
     closeTag = Combine(_L("</") + tagStr + ">")
 
-    openTag = openTag.setResultsName("start"+"".join(resname.replace(":"," ").title().split())).setName("<%s>" % resname)
-    closeTag = closeTag.setResultsName("end"+"".join(resname.replace(":"," ").title().split())).setName("</%s>" % resname)
+    openTag = openTag.setResultsName("start"+"".join(resname.replace(":"," ").title().split())).setName("<{0!s}>".format(resname))
+    closeTag = closeTag.setResultsName("end"+"".join(resname.replace(":"," ").title().split())).setName("</{0!s}>".format(resname))
     openTag.tag = resname
     closeTag.tag = resname
     return openTag, closeTag
@@ -3028,8 +3028,7 @@ def withAttribute(*args,**attrDict):
             if attrName not in tokens:
                 raise ParseException(s, l, "no matching attribute " + attrName)
             if attrValue != withAttribute.ANY_VALUE and tokens[attrName] != attrValue:
-                raise ParseException(s, l, "attribute '%s' has value '%s', must be '%s'" %
-                                     (attrName, tokens[attrName], attrValue))
+                raise ParseException(s, l, "attribute '{0!s}' has value '{1!s}', must be '{2!s}'".format(attrName, tokens[attrName], attrValue))
     return pa
 withAttribute.ANY_VALUE = object()
 
@@ -3037,7 +3036,7 @@ def withClass(classname, namespace=''):
     """Simplified version of C{L{withAttribute}} when matching on a div class - made
        difficult because C{class} is a reserved word in Python.
        """
-    classattr = "%s:class" % namespace if namespace else "class"
+    classattr = "{0!s}:class".format(namespace) if namespace else "class"
     return withAttribute(**{classattr : classname})
 
 opAssoc = _Constants()
@@ -3074,7 +3073,7 @@ def infixNotation( baseExpr, opList, lpar=Suppress('('), rpar=Suppress(')') ):
     lastExpr = baseExpr | ( lpar + ret + rpar )
     for i,operDef in enumerate(opList):
         opExpr,arity,rightLeftAssoc,pa = (operDef + (None,))[:4]
-        termName = "%s term" % opExpr if arity < 3 else "%s%s term" % opExpr
+        termName = "{0!s} term".format(opExpr) if arity < 3 else "{0!s}{1!s} term".format(*opExpr)
         if arity == 3:
             if opExpr is None or len(opExpr) != 2:
                 raise ValueError("if numterms=3, opExpr must be a tuple or list of two expressions")
@@ -3180,7 +3179,7 @@ def nestedExpr(opener="(", closer=")", content=None, ignoreExpr=quotedString.cop
         ret <<= Group( Suppress(opener) + ZeroOrMore( ignoreExpr | ret | content ) + Suppress(closer) )
     else:
         ret <<= Group( Suppress(opener) + ZeroOrMore( ret | content )  + Suppress(closer) )
-    ret.setName('nested %s%s expression' % (opener,closer))
+    ret.setName('nested {0!s}{1!s} expression'.format(opener, closer))
     return ret
 
 def indentedBlock(blockStatementExpr, indentStack, indent=True):

--- a/test/unitTests.py
+++ b/test/unitTests.py
@@ -96,7 +96,7 @@ if 0:
 
                 allToks = flatten( results.asList() )
                 assert len(allToks) == numToks, \
-                    "wrong number of tokens parsed (%s), got %d, expected %d" % (testFile, len(allToks),numToks)
+                    "wrong number of tokens parsed ({0!s}), got {1:d}, expected {2:d}".format(testFile, len(allToks), numToks)
                 assert results.batchData.trackInputUsed == trkInpUsed, "error evaluating results.batchData.trackInputUsed"
                 assert results.batchData.trackOutputUsed == trkOutpUsed, "error evaluating results.batchData.trackOutputUsed"
                 assert results.batchData.maxDelta == maxDelta,"error evaluating results.batchData.maxDelta"
@@ -123,7 +123,7 @@ class ParseFourFnTest(ParseTestCase):
             fourFn.exprStack = []
             results = fourFn.BNF().parseString( s )
             resultValue = fourFn.evaluateStack( fourFn.exprStack )
-            assert resultValue == ans, "failed to evaluate %s, got %f" % ( s, resultValue )
+            assert resultValue == ans, "failed to evaluate {0!s}, got {1:f}".format(s, resultValue )
             print_(s, "->", resultValue)
         
         from math import pi,exp
@@ -194,7 +194,7 @@ class ParseConfigFileTest(ParseTestCase):
             print_(list(iniData.keys()))
             #~ print iniData.users.keys()
             #~ print
-            assert len(flatten(iniData.asList())) == numToks, "file %s not parsed correctly" % fnam
+            assert len(flatten(iniData.asList())) == numToks, "file {0!s} not parsed correctly".format(fnam)
             for chk in resCheckList:
                 print_(chk[0], eval("iniData."+chk[0]), chk[1])
                 assert eval("iniData."+chk[0]) == chk[1]
@@ -261,7 +261,7 @@ class ParseCommaSeparatedValuesTest(ParseTestCase):
                 if not(len(results)>t[0] and results[t[0]] == t[1]):
                     print_("$$$", results.dump())
                     print_("$$$", results[0])
-                assert len(results)>t[0] and results[t[0]] == t[1],"failed on %s, item %d s/b '%s', got '%s'" % ( line, t[0], t[1], str(results.asList()) )
+                assert len(results)>t[0] and results[t[0]] == t[1],"failed on {0!s}, item {1:d} s/b '{2!s}', got '{3!s}'".format(line, t[0], t[1], str(results.asList()) )
 
 class ParseEBNFTest(ParseTestCase):
     def runTest(self):
@@ -323,13 +323,13 @@ class ParseIDLTest(ParseTestCase):
                 pprint.pprint( tokens.asList() )
                 tokens = flatten( tokens.asList() )
                 print_(len(tokens))
-                assert len(tokens) == numToks, "error matching IDL string, %s -> %s" % (strng, str(tokens) )
+                assert len(tokens) == numToks, "error matching IDL string, {0!s} -> {1!s}".format(strng, str(tokens) )
             except ParseException as err:
                 print_(err.line)
                 print_(" "*(err.column-1) + "^")
                 print_(err)
-                assert numToks == 0, "unexpected ParseException while parsing %s, %s" % (strng, str(err) )
-                assert err.loc == errloc, "expected ParseException at %d, found exception at %d" % (errloc, err.loc)
+                assert numToks == 0, "unexpected ParseException while parsing {0!s}, {1!s}".format(strng, str(err) )
+                assert err.loc == errloc, "expected ParseException at {0:d}, found exception at {1:d}".format(errloc, err.loc)
             
         test(
             """
@@ -515,16 +515,16 @@ class QuotedStringsTest(ParseTestCase):
         sglStrings = [ (t[0],b,e) for (t,b,e) in sglQuotedString.scanString(escapedQuoteTest) ]
         print_(sglStrings)
         assert len(sglStrings) == 1 and (sglStrings[0][1]==17 and sglStrings[0][2]==66), \
-            "single quoted string escaped quote failure (%s)" % str(sglStrings[0])
+            "single quoted string escaped quote failure ({0!s})".format(str(sglStrings[0]))
         dblStrings = [ (t[0],b,e) for (t,b,e) in dblQuotedString.scanString(escapedQuoteTest) ]
         print_(dblStrings)
         assert len(dblStrings) == 1 and (dblStrings[0][1]==83 and dblStrings[0][2]==132), \
-            "double quoted string escaped quote failure (%s)" % str(dblStrings[0])
+            "double quoted string escaped quote failure ({0!s})".format(str(dblStrings[0]))
         allStrings = [ (t[0],b,e) for (t,b,e) in quotedString.scanString(escapedQuoteTest) ]
         print_(allStrings)
         assert len(allStrings) == 2 and (allStrings[0][1]==17 and allStrings[0][2]==66 and
                                           allStrings[1][1]==83 and allStrings[1][2]==132), \
-            "quoted string escaped quote failure (%s)" % ([str(s[0]) for s in allStrings])
+            "quoted string escaped quote failure ({0!s})".format(([str(s[0]) for s in allStrings]))
         
         dblQuoteTest = \
             r"""
@@ -534,16 +534,16 @@ class QuotedStringsTest(ParseTestCase):
         sglStrings = [ (t[0],b,e) for (t,b,e) in sglQuotedString.scanString(dblQuoteTest) ]
         print_(sglStrings)
         assert len(sglStrings) == 1 and (sglStrings[0][1]==17 and sglStrings[0][2]==66), \
-            "single quoted string escaped quote failure (%s)" % str(sglStrings[0])
+            "single quoted string escaped quote failure ({0!s})".format(str(sglStrings[0]))
         dblStrings = [ (t[0],b,e) for (t,b,e) in dblQuotedString.scanString(dblQuoteTest) ]
         print_(dblStrings)
         assert len(dblStrings) == 1 and (dblStrings[0][1]==83 and dblStrings[0][2]==132), \
-            "double quoted string escaped quote failure (%s)" % str(dblStrings[0])
+            "double quoted string escaped quote failure ({0!s})".format(str(dblStrings[0]))
         allStrings = [ (t[0],b,e) for (t,b,e) in quotedString.scanString(dblQuoteTest) ]
         print_(allStrings)
         assert len(allStrings) == 2 and (allStrings[0][1]==17 and allStrings[0][2]==66 and
                                           allStrings[1][1]==83 and allStrings[1][2]==132), \
-            "quoted string escaped quote failure (%s)" % ([str(s[0]) for s in allStrings])
+            "quoted string escaped quote failure ({0!s})".format(([str(s[0]) for s in allStrings]))
 
         print_("testing catastrophic RE backtracking in implementation of dblQuotedString")
         for expr, test_string in [
@@ -772,7 +772,7 @@ class ParseExpressionResultsTest(ParseTestCase):
         print_(results,results.Head, results.ABC,results.Tail)
         for key,ln in [("Head",2), ("ABC",3), ("Tail",2)]:
             #~ assert len(results[key]) == ln,"expected %d elements in %s, found %s" % (ln, key, str(results[key].asList()))
-            assert len(results[key]) == ln,"expected %d elements in %s, found %s" % (ln, key, str(results[key]))
+            assert len(results[key]) == ln,"expected {0:d} elements in {1!s}, found {2!s}".format(ln, key, str(results[key]))
         
 
 class ParseKeywordTest(ParseTestCase):
@@ -789,18 +789,18 @@ class ParseKeywordTest(ParseTestCase):
                 print_(lit.parseString(s))
             except:
                 print_("failed")
-                if litShouldPass: assert False, "Literal failed to match %s, should have" % s
+                if litShouldPass: assert False, "Literal failed to match {0!s}, should have".format(s)
             else:
-                if not litShouldPass: assert False, "Literal matched %s, should not have" % s
+                if not litShouldPass: assert False, "Literal matched {0!s}, should not have".format(s)
         
             print_("Match Keyword", end=' ')
             try:
                 print_(kw.parseString(s))
             except:
                 print_("failed")
-                if kwShouldPass: assert False, "Keyword failed to match %s, should have" % s
+                if kwShouldPass: assert False, "Keyword failed to match {0!s}, should have".format(s)
             else:
-                if not kwShouldPass: assert False, "Keyword matched %s, should not have" % s
+                if not kwShouldPass: assert False, "Keyword matched {0!s}, should not have".format(s)
         
         test("ifOnlyIfOnly", True, False)
         test("if(OnlyIfOnly)", True, True)
@@ -828,11 +828,11 @@ class ParseExpressionResultsAccumulateTest(ParseTestCase):
                              ("hex",2,['0x2','0x4']),
                              ("word",1,['aaa']) ):
             print_(k,tokens[k])
-            assert len(tokens[k]) == llen, "Wrong length for key %s, %s" % (k,str(tokens[k].asList()))
-            assert lst == tokens[k].asList(), "Incorrect list returned for key %s, %s" % (k,str(tokens[k].asList()))
-        assert tokens.base10.asList() == ['1','3'], "Incorrect list for attribute base10, %s" % str(tokens.base10.asList())
-        assert tokens.hex.asList() == ['0x2','0x4'], "Incorrect list for attribute hex, %s" % str(tokens.hex.asList())
-        assert tokens.word.asList() == ['aaa'], "Incorrect list for attribute word, %s" % str(tokens.word.asList())
+            assert len(tokens[k]) == llen, "Wrong length for key {0!s}, {1!s}".format(k, str(tokens[k].asList()))
+            assert lst == tokens[k].asList(), "Incorrect list returned for key {0!s}, {1!s}".format(k, str(tokens[k].asList()))
+        assert tokens.base10.asList() == ['1','3'], "Incorrect list for attribute base10, {0!s}".format(str(tokens.base10.asList()))
+        assert tokens.hex.asList() == ['0x2','0x4'], "Incorrect list for attribute hex, {0!s}".format(str(tokens.hex.asList()))
+        assert tokens.word.asList() == ['aaa'], "Incorrect list for attribute word, {0!s}".format(str(tokens.word.asList()))
 
         from pyparsing import Literal, Word, nums, Group, Dict, alphas, \
             quotedString, oneOf, delimitedList, removeQuotes, alphanums
@@ -852,7 +852,7 @@ class ParseExpressionResultsAccumulateTest(ParseTestCase):
         
         queryRes = Query.parseString(test)
         print_("pred",queryRes.pred)
-        assert queryRes.pred.asList() == [['y', '>', '28'], ['x', '<', '12'], ['x', '>', '3']], "Incorrect list for attribute pred, %s" % str(queryRes.pred.asList())
+        assert queryRes.pred.asList() == [['y', '>', '28'], ['x', '<', '12'], ['x', '>', '3']], "Incorrect list for attribute pred, {0!s}".format(str(queryRes.pred.asList()))
         print_(queryRes.dump())
 
 class ReStringRangeTest(ParseTestCase):
@@ -910,7 +910,7 @@ class ReStringRangeTest(ParseTestCase):
             t,exp = test
             res = pyparsing.srange(t)
             #print_(t,"->",res)
-            assert res == exp, "srange error, srange(%r)->'%r', expected '%r'" % (t, res, exp)
+            assert res == exp, "srange error, srange({0!r})->'{1!r}', expected '{2!r}'".format(t, res, exp)
 
 class SkipToParserTests(ParseTestCase):
     def runTest(self):
@@ -925,8 +925,8 @@ class SkipToParserTests(ParseTestCase):
                 print_(testExpr.parseString(someText))
                 assert not fail_expected, "expected failure but no exception raised"
             except Exception as e:
-                print_("Exception %s while parsing string %s" % (e,repr(someText)))
-                assert fail_expected and isinstance(e,ParseBaseException), "Exception %s while parsing string %s" % (e,repr(someText))
+                print_("Exception {0!s} while parsing string {1!s}".format(e, repr(someText)))
+                assert fail_expected and isinstance(e,ParseBaseException), "Exception {0!s} while parsing string {1!s}".format(e, repr(someText))
     
         # This first test works, as the SkipTo expression is immediately following the ignore expression (cStyleComment)
         tryToParse('some text /* comment with ; in */; working')
@@ -962,8 +962,7 @@ class CustomQuotesTest(ParseTestCase):
             print_(quoteExpr.searchString(testString)[0][0])
             print_(expected)
             assert quoteExpr.searchString(testString)[0][0] == expected, \
-                    "failed to match %s, expected '%s', got '%s'" % \
-                    (quoteExpr,expected,quoteExpr.searchString(testString)[0])
+                    "failed to match {0!s}, expected '{1!s}', got '{2!s}'".format(quoteExpr, expected, quoteExpr.searchString(testString)[0])
             print_()
         
         test(colonQuotes, r"sdf:jls:djf")
@@ -1011,7 +1010,7 @@ class RepeaterTest(ParseTestCase):
                 found = True
             if not found:
                 print_("No literal match in", tst)
-            assert found == result, "Failed repeater for test: %s, matching %s" % (tst, str(seq))
+            assert found == result, "Failed repeater for test: {0!s}, matching {1!s}".format(tst, str(seq))
         print_()
 
         # retest using matchPreviousExpr instead of matchPreviousLiteral
@@ -1031,7 +1030,7 @@ class RepeaterTest(ParseTestCase):
                 found = True
             if not found:
                 print_("No expression match in", tst)
-            assert found == result, "Failed repeater for test: %s, matching %s" % (tst, str(seq))
+            assert found == result, "Failed repeater for test: {0!s}, matching {1!s}".format(tst, str(seq))
 
         print_()
 
@@ -1078,7 +1077,7 @@ class RepeaterTest(ParseTestCase):
                 break
             if not found:
                 print_("No expression match in", tst)
-            assert found == result, "Failed repeater for test: %s, matching %s" % (tst, str(seq))
+            assert found == result, "Failed repeater for test: {0!s}, matching {1!s}".format(tst, str(seq))
 
         print_()
         eFirst = Word(nums)
@@ -1099,7 +1098,7 @@ class RepeaterTest(ParseTestCase):
                 found = True
             if not found:
                 print_("No match in", tst)
-            assert found == result, "Failed repeater for test: %s, matching %s" % (tst, str(seq))
+            assert found == result, "Failed repeater for test: {0!s}, matching {1!s}".format(tst, str(seq))
 
 class RecursiveCombineTest(ParseTestCase):
     def runTest(self):
@@ -1165,7 +1164,7 @@ class InfixNotationGrammarTest1(ParseTestCase):
         expected = [eval(x) for x in expected]
         for t,e in zip(test,expected):
             print_(t,"->",e, "got", expr.parseString(t).asList())
-            assert expr.parseString(t).asList() == e,"mismatched results for infixNotation: got %s, expected %s" % (expr.parseString(t).asList(),e)
+            assert expr.parseString(t).asList() == e,"mismatched results for infixNotation: got {0!s}, expected {1!s}".format(expr.parseString(t).asList(), e)
 
 class InfixNotationGrammarTest2(ParseTestCase):
     def runTest(self):
@@ -1177,7 +1176,7 @@ class InfixNotationGrammarTest2(ParseTestCase):
             def __init__(self,t):
                 self.args = t[0][0::2]
             def __str__(self):
-                sep = " %s " % self.reprsymbol
+                sep = " {0!s} ".format(self.reprsymbol)
                 return "(" + sep.join(map(str,self.args)) + ")"
             
         class BoolAnd(BoolOperand):
@@ -1283,7 +1282,7 @@ class InfixNotationGrammarTest3(ParseTestCase):
         test = ["9"]
         for t in test:
             count = 0
-            print_("%s => %s" % (t, expr.parseString(t)))
+            print_("{0!s} => {1!s}".format(t, expr.parseString(t)))
             assert count == 1, "count evaluated too many times!"
 
 class InfixNotationGrammarTest4(ParseTestCase):
@@ -1315,7 +1314,7 @@ class InfixNotationGrammarTest4(ParseTestCase):
             print_(test)
             results = f.parseString(test)
             print_(results)
-            assert str(results) == expected, "failed to match expected results, got '%s'" % str(results)
+            assert str(results) == expected, "failed to match expected results, got '{0!s}'".format(str(results))
             print_()
 
 
@@ -1325,8 +1324,8 @@ class PickleTest_Greeting():
         self.greetee = toks[1]
         
     def __repr__(self):
-        return "%s: {%s}" % (self.__class__.__name__, 
-            ', '.join('%r: %r' % (k, getattr(self,k)) for k in sorted(self.__dict__)))
+        return "{0!s}: {{{1!s}}}".format(self.__class__.__name__, 
+            ', '.join('{0!r}: {1!r}'.format(k, getattr(self,k)) for k in sorted(self.__dict__)))
         
 class ParseResultsPickleTest(ParseTestCase):
     def runTest(self):
@@ -1353,7 +1352,7 @@ class ParseResultsPickleTest(ParseTestCase):
                     print_(newresult.dump())
                     print_()
 
-            assert result.dump() == newresult.dump(), "Error pickling ParseResults object (protocol=%d)" % protocol
+            assert result.dump() == newresult.dump(), "Error pickling ParseResults object (protocol={0:d})".format(protocol)
 
         # test 2
         import pyparsing as pp
@@ -1380,7 +1379,7 @@ class ParseResultsPickleTest(ParseTestCase):
             else:
                 newresult = pickle.loads(pickleString)
             print_(newresult.dump())
-            assert newresult.dump() == result.dump(), "failed to pickle/unpickle ParseResults: expected %r, got %r" % (result, newresult)
+            assert newresult.dump() == result.dump(), "failed to pickle/unpickle ParseResults: expected {0!r}, got {1!r}".format(result, newresult)
 
 
 
@@ -1427,13 +1426,13 @@ class ParseHTMLTagsTest(ParseTestCase):
             
             tType = t.getName() 
             #~ print tType,"==",expectedType,"?"
-            assert tType in "startBody endBody".split(), "parsed token of unknown type '%s'" % tType
-            assert tType == expectedType, "expected token of type %s, got %s" % (expectedType, tType) 
+            assert tType in "startBody endBody".split(), "parsed token of unknown type '{0!s}'".format(tType)
+            assert tType == expectedType, "expected token of type {0!s}, got {1!s}".format(expectedType, tType) 
             if tType == "startBody":
-                assert bool(t.empty) == expectedEmpty, "expected %s token, got %s" % ( expectedEmpty and "empty" or "not empty", 
+                assert bool(t.empty) == expectedEmpty, "expected {0!s} token, got {1!s}".format(expectedEmpty and "empty" or "not empty", 
                                                                                                 t.empty and "empty" or "not empty" )
-                assert t.bgcolor == expectedBG, "failed to match BGCOLOR, expected %s, got %s" % ( expectedBG, t.bgcolor )
-                assert t.fgcolor == expectedFG, "failed to match FGCOLOR, expected %s, got %s" % ( expectedFG, t.bgcolor )
+                assert t.bgcolor == expectedBG, "failed to match BGCOLOR, expected {0!s}, got {1!s}".format(expectedBG, t.bgcolor )
+                assert t.fgcolor == expectedFG, "failed to match FGCOLOR, expected {0!s}, got {1!s}".format(expectedFG, t.bgcolor )
             elif tType == "endBody":
                 #~ print "end tag"
                 pass
@@ -1497,23 +1496,20 @@ class ParseUsingRegex(ParseTestCase):
             if shouldPass:
                 try:
                     result = expression.parseString(instring)
-                    print_('%s correctly matched %s' % (repr(expression), repr(instring)))
+                    print_('{0!s} correctly matched {1!s}'.format(repr(expression), repr(instring)))
                     if expectedString != result[0]:
                         print_('\tbut failed to match the pattern as expected:')
-                        print_('\tproduced %s instead of %s' % \
-                            (repr(result[0]), repr(expectedString)))
+                        print_('\tproduced {0!s} instead of {1!s}'.format(repr(result[0]), repr(expectedString)))
                     return True
                 except pyparsing.ParseException:
-                    print_('%s incorrectly failed to match %s' % \
-                        (repr(expression), repr(instring)))
+                    print_('{0!s} incorrectly failed to match {1!s}'.format(repr(expression), repr(instring)))
             else:
                 try:
                     result = expression.parseString(instring)
-                    print_('%s incorrectly matched %s' % (repr(expression), repr(instring)))
-                    print_('\tproduced %s as a result' % repr(result[0]))
+                    print_('{0!s} incorrectly matched {1!s}'.format(repr(expression), repr(instring)))
+                    print_('\tproduced {0!s} as a result'.format(repr(result[0])))
                 except pyparsing.ParseException:
-                    print_('%s correctly failed to match %s' % \
-                        (repr(expression), repr(instring)))
+                    print_('{0!s} correctly failed to match {1!s}'.format(repr(expression), repr(instring)))
                     return True
             return False
         
@@ -1663,7 +1659,7 @@ class LineAndStringEndTest(ParseTestCase):
             except ParseException as pe:
                 res = None
             print_(res)
-            assert res == expected, "Failed on parseAll=True test %d" % i
+            assert res == expected, "Failed on parseAll=True test {0:d}".format(i)
 
 class VariableParseActionArgsTest(ParseTestCase):
     def runTest(self):
@@ -1857,7 +1853,7 @@ class OriginalTextForTest(ParseTestCase):
         from pyparsing import makeHTMLTags, originalTextFor
         
         def rfn(t):
-            return "%s:%d" % (t.src, len("".join(t)))
+            return "{0!s}:{1:d}".format(t.src, len("".join(t)))
 
         makeHTMLStartTag = lambda tag: originalTextFor(makeHTMLTags(tag)[0], asString=False)
             
@@ -1903,7 +1899,7 @@ class PackratParsingCacheCopyTest(ParseTestCase):
         program = varDec | funcDef
         input = 'int f(){}'
         results = program.parseString(input)
-        print_("Parsed '%s' as %s" % (input, results.asList()))
+        print_("Parsed '{0!s}' as {1!s}".format(input, results.asList()))
         assert results.asList() == ['int', 'f', '(', ')', '{}'], "Error in packrat parsing"
 
 class PackratParsingCacheCopyTest2(ParseTestCase):
@@ -1989,7 +1985,7 @@ class WithAttributeParseActionTest(ParseTestCase):
             result = expr.searchString(data)
           
             print_(result.dump())
-            assert result.asList() == exp, "Failed test, expected %s, got %s" % (expected, result.asList())
+            assert result.asList() == exp, "Failed test, expected {0!s}, got {1!s}".format(expected, result.asList())
 
 class NestedExpressionsTest(ParseTestCase):
     def runTest(self):
@@ -2019,7 +2015,7 @@ class NestedExpressionsTest(ParseTestCase):
         expected = [[['ax', '+', 'by'], '*C']]
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected, "Defaults didn't work. That's a bad sign. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected, "Defaults didn't work. That's a bad sign. Expected: {0!s}, got: {1!s}".format(expected, result)
 
         #Going through non-defaults, one by one; trying to think of anything
         #odd that might not be properly handled.
@@ -2032,7 +2028,7 @@ class NestedExpressionsTest(ParseTestCase):
         expr = nestedExpr("[")
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected, "Non-default opener didn't work. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected, "Non-default opener didn't work. Expected: {0!s}, got: {1!s}".format(expected, result)
 
         #Change closer
         print_("\nNon-default closer")
@@ -2042,7 +2038,7 @@ class NestedExpressionsTest(ParseTestCase):
         expr = nestedExpr(closer="]")
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected, "Non-default closer didn't work. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected, "Non-default closer didn't work. Expected: {0!s}, got: {1!s}".format(expected, result)
 
         # #Multicharacter opener, closer
         # opener = "bar"
@@ -2058,7 +2054,7 @@ class NestedExpressionsTest(ParseTestCase):
         # expr = nestedExpr(opener, closer)
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected, "Multicharacter opener and closer didn't work. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected, "Multicharacter opener and closer didn't work. Expected: {0!s}, got: {1!s}".format(expected, result)
 
         #Lisp-ish comments
         print_("\nUse ignore expression (1)")
@@ -2074,7 +2070,7 @@ class NestedExpressionsTest(ParseTestCase):
         expr = nestedExpr(ignoreExpr=comment)
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected , "Lisp-ish comments (\";; <...> $\") didn't work. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected , "Lisp-ish comments (\";; <...> $\") didn't work. Expected: {0!s}, got: {1!s}".format(expected, result)
 
 
         #Lisp-ish comments, using a standard bit of pyparsing, and an Or.
@@ -2092,7 +2088,7 @@ class NestedExpressionsTest(ParseTestCase):
         expr = nestedExpr(ignoreExpr=(comment ^ quotedString))
         result = expr.parseString(teststring)
         print_(result.dump())
-        assert result.asList() == expected , "Lisp-ish comments (\";; <...> $\") and quoted strings didn't work. Expected: %s, got: %s" % (expected, result)
+        assert result.asList() == expected , "Lisp-ish comments (\";; <...> $\") and quoted strings didn't work. Expected: {0!s}, got: {1!s}".format(expected, result)
 
 class WordExcludeTest(ParseTestCase):
     def runTest(self):
@@ -2118,7 +2114,7 @@ class ParseAllTest(ParseTestCase):
             ]
         for s,parseAllFlag,shouldSucceed in tests:
             try:
-                print_("'%s' parseAll=%s (shouldSuceed=%s)" % (s, parseAllFlag, shouldSucceed))
+                print_("'{0!s}' parseAll={1!s} (shouldSuceed={2!s})".format(s, parseAllFlag, shouldSucceed))
                 testExpr.parseString(s,parseAllFlag)
                 assert shouldSucceed, "successfully parsed when should have failed"
             except ParseException as pe:
@@ -2135,7 +2131,7 @@ class ParseAllTest(ParseTestCase):
             ]
         for s,parseAllFlag,shouldSucceed in tests:
             try:
-                print_("'%s' parseAll=%s (shouldSucceed=%s)" % (s, parseAllFlag, shouldSucceed))
+                print_("'{0!s}' parseAll={1!s} (shouldSucceed={2!s})".format(s, parseAllFlag, shouldSucceed))
                 testExpr.parseString(s,parseAllFlag)
                 assert shouldSucceed, "successfully parsed when should have failed"
             except ParseException as pe:
@@ -2157,9 +2153,9 @@ class GreedyQuotedStringsTest(ParseTestCase):
         for expr in testExprs:
             strs = delimitedList(expr).searchString(src)
             print_(strs)
-            assert bool(strs), "no matches found for test expression '%s'"  % expr
+            assert bool(strs), "no matches found for test expression '{0!s}'".format(expr)
             for lst in strs:
-                assert len(lst) == 2, "invalid match found for test expression '%s'"  % expr
+                assert len(lst) == 2, "invalid match found for test expression '{0!s}'".format(expr)
                 
         from pyparsing import alphas, nums, Word
         src = """'ms1',1,0,'2009-12-22','2009-12-22 10:41:22') ON DUPLICATE KEY UPDATE sent_count = sent_count + 1, mtime = '2009-12-22 10:41:22';"""
@@ -2221,7 +2217,7 @@ class WordBoundaryExpressionsTest(ParseTestCase):
                 bnf,
                 ]]
             print_(results)
-            assert results==expected,"Failed WordBoundaryTest, expected %s, got %s" % (expected,results)
+            assert results==expected,"Failed WordBoundaryTest, expected {0!s}, got {1!s}".format(expected, results)
             print_()
 
 class RequiredEachTest(ParseTestCase):
@@ -2295,7 +2291,7 @@ class SumParseResultsTest(ParseTestCase):
         results = (res1, res2, res3, res4,)
         for test,expected in zip(tests, results):
             person = sum(person_data.searchString(test))
-            result = "ID:%s DOB:%s INFO:%s" % (person.id, person.dob, person.info)
+            result = "ID:{0!s} DOB:{1!s} INFO:{2!s}".format(person.id, person.dob, person.info)
             print_(test)
             print_(expected)
             print_(result)
@@ -2303,7 +2299,7 @@ class SumParseResultsTest(ParseTestCase):
                 print_(pd.dump())
             print_()
             assert expected == result, \
-                "Failed to parse '%s' correctly, \nexpected '%s', got '%s'" % (test,expected,result)
+                "Failed to parse '{0!s}' correctly, \nexpected '{1!s}', got '{2!s}'".format(test, expected, result)
 
 class MarkInputLineTest(ParseTestCase):
     def runTest(self):
@@ -2359,16 +2355,16 @@ class PopTest(ParseTestCase):
             print_("EXP:", val, remaining)
             print_("GOT:", ret, result.asList())
             print_(ret, result.asList())
-            assert ret == val, "wrong value returned, got %r, expected %r" % (ret, val)
-            assert remaining == result.asList(), "list is in wrong state after pop, got %r, expected %r" % (result.asList(), remaining)
+            assert ret == val, "wrong value returned, got {0!r}, expected {1!r}".format(ret, val)
+            assert remaining == result.asList(), "list is in wrong state after pop, got {0!r}, expected {1!r}".format(result.asList(), remaining)
             print_()
 
         prevlist = result.asList()
         ret = result.pop('name', default="noname")
         print_(ret)
         print_(result.asList())
-        assert ret == "noname", "default value not successfully returned, got %r, expected %r" % (ret, "noname")
-        assert result.asList() == prevlist, "list is in wrong state after pop, got %r, expected %r" % (result.asList(), remaining)
+        assert ret == "noname", "default value not successfully returned, got {0!r}, expected {1!r}".format(ret, "noname")
+        assert result.asList() == prevlist, "list is in wrong state after pop, got {0!r}, expected {1!r}".format(result.asList(), remaining)
 
 
 class AddConditionTest(ParseTestCase):
@@ -2426,7 +2422,7 @@ class PatientOrTest(ParseTestCase):
         # (which is too late)... 
         try:
             result = (a ^ b ^ c).parseString("def")
-            assert result.asList() == ['de'], "failed to select longest match, chose %s" % result
+            assert result.asList() == ['de'], "failed to select longest match, chose {0!s}".format(result)
         except ParseException:
             failed = True
         else:
@@ -2451,7 +2447,7 @@ class UnicodeExpressionTest(ParseTestCase):
             z.parseString('b')
         except ParseException as pe:
             if not PY_3:
-                assert pe.msg == r'''Expected {"a" | "\u1111"}''', "Invalid error message raised, got %r" % pe.msg
+                assert pe.msg == r'''Expected {"a" | "\u1111"}''', "Invalid error message raised, got {0!r}".format(pe.msg)
 
 class SetNameTest(ParseTestCase):
     def runTest(self):
@@ -2531,13 +2527,13 @@ class OneOrMoreStopTest(ParseTestCase):
         body_word = Word(alphas).setName("word")
         for ender in (END, "END", CaselessKeyword("END")):
             expr = BEGIN + OneOrMore(body_word, stopOn=ender) + END
-            assert test == expr, "Did not successfully stop on ending expression %r" % ender
+            assert test == expr, "Did not successfully stop on ending expression {0!r}".format(ender)
         
         number = Word(nums+',.()').setName("number with optional commas")
         parser= (OneOrMore(Word(alphanums+'-/.'), stopOn=number)('id').setParseAction(' '.join) 
                     + number('data'))
         result = parser.parseString('        XXX Y/123          1,234.567890')
-        assert result.asList() == ['XXX Y/123', '1,234.567890'], "Did not successfully stop on ending expression %r" % number
+        assert result.asList() == ['XXX Y/123', '1,234.567890'], "Did not successfully stop on ending expression {0!r}".format(number)
 
 class ZeroOrMoreStopTest(ParseTestCase):
     def runTest(self):
@@ -2548,7 +2544,7 @@ class ZeroOrMoreStopTest(ParseTestCase):
         body_word = Word(alphas).setName("word")
         for ender in (END, "END", CaselessKeyword("END")):
             expr = BEGIN + ZeroOrMore(body_word, stopOn=ender) + END
-            assert test == expr, "Did not successfully stop on ending expression %r" % ender
+            assert test == expr, "Did not successfully stop on ending expression {0!r}".format(ender)
         
 class NestedAsDictTest(ParseTestCase):
     def runTest(self):
@@ -2960,7 +2956,7 @@ class MiscellaneousParserTests(ParseTestCase):
                 testGrammar.parseString("AC")
             except pyparsing.ParseException as pe:
                 print_(pe.pstr,"->",pe)
-                assert False, "error in Optional matching of string %s" % pe.pstr
+                assert False, "error in Optional matching of string {0!s}".format(pe.pstr)
         
         # test return of furthest exception
         if "E" in runtests:
@@ -3130,7 +3126,7 @@ if console:
         if lp is None:
             testRunner.run( makeTestSuiteTemp(testclasses) )
         else:
-            lp.run("testRunner.run( makeTestSuite(%s) )" % testclass.__name__)
+            lp.run("testRunner.run( makeTestSuite({0!s}) )".format(testclass.__name__))
 else:
     # HTML mode
     outfile = "testResults.html"


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:vmuriart:pyparsing?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:vmuriart:pyparsing?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
